### PR TITLE
Further Improved Inventory Report

### DIFF
--- a/32-Inventory-Report-16.393/16.31.exploit-LRFLEW.asm
+++ b/32-Inventory-Report-16.393/16.31.exploit-LRFLEW.asm
@@ -1,29 +1,28 @@
 -- HUMAN RESOURCE MACHINE PROGRAM --
--- 32-Inventory-Report - SIZE 18/16 - SPEED 32/393 --
+-- 32-Inventory-Report - SIZE 16/16 - SPEED 31/393 --
 
 -- Relies on a fixed floor where occurrences are: A=4, B=5, C=2, X=3
 
-    COPYFROM 4
-    SUB      1
-    COPYTO   0
-    COPYTO   1
-    BUMPUP   1
-    ADD      1
-    COPYTO   2
+    BUMPUP   14
+    BUMPUP   14
+    COPYTO   13
+    BUMPUP   13
     JUMP     d
 a:
-    ADD      2
+    ADD      13
+    ADD      13
 b:
 c:
     OUTBOX  
 d:
     INBOX   
-    SUB      4
+    SUB      10
     JUMPN    a
     JUMPZ    e
-    COPYFROM 1
+    COPYFROM 13
     JUMP     c
 e:
-    COPYFROM 0
+    COPYFROM 14
     JUMP     b
+
 


### PR DESCRIPTION
I was able to reduce both my speed by 1 and my length by 2.

The first improvement was copied from 13.53.exploit-skwasjer.asm. The first three lines of my solution (which generates and saves the value 2) was made faster by 1 line by switching to Bumps. This reduced my speed and length by 1.

The second improvement was in length only. Instead of precomputing 3+3, I perform an additional add in the code. This doesn't improve the speed because that second add is run twice, but it does decrease the length by 1 as it removes a CopyTo.