### PR TITLE
Separate tables for input-specific and non-input specific solutions

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -216,6 +216,8 @@ gulp.task('deploy-data-programs', [ 'deploy-clean' ], function () {
                 steps: data.path.reportedSpeed, // data.averageSteps, // @todo until step measurement matches game's
                 successRatio: data.successRatio,
                 type: data.path.type,
+                legal: ( (!/(exploit|specific|obsolete)/.exec(data.path.type)) && ((data.successRatio == 1) || ([4, 28, 41].includes(data.level.number))) ),
+                worky: ((data.successRatio == 1) || ([4, 28, 41].includes(data.level.number))),
                 author: data.path.author,
                 hash: md5(data.source),
                 path: data.path.full
@@ -250,7 +252,7 @@ gulp.task('deploy-page', [ 'deploy-data' ], function () {
         });
 
         return extend({}, level, {
-            minSizeProgram: programs.reduce(function (minSizeProgram, program) {
+            minSizeProgram: programs.filter(program => program.legal).reduce(function (minSizeProgram, program) {
                 if (program.size < minSizeProgram.size
                     || program.size === minSizeProgram.size && program.steps < minSizeProgram.steps) {
                     minSizeProgram = program;
@@ -258,7 +260,7 @@ gulp.task('deploy-page', [ 'deploy-data' ], function () {
 
                 return minSizeProgram;
             }),
-            minSizeParProgram: programs.reduce(function (minSizeParProgram, program) {
+            minSizeParProgram: programs.filter(program => program.legal).reduce(function (minSizeParProgram, program) {
                 if (program.steps <= level.challenge.speed) {
                     if (minSizeParProgram.steps > level.challenge.speed) {
                         minSizeParProgram = program;
@@ -271,7 +273,7 @@ gulp.task('deploy-page', [ 'deploy-data' ], function () {
 
                 return minSizeParProgram;
             }),
-            minStepsProgram: programs.reduce(function (minStepsProgram, program) {
+            minStepsProgram: programs.filter(program => program.legal).reduce(function (minStepsProgram, program) {
                 if (program.steps < minStepsProgram.steps
                     || program.steps === minStepsProgram.steps && program.size < minStepsProgram.size) {
                     minStepsProgram = program;
@@ -279,7 +281,7 @@ gulp.task('deploy-page', [ 'deploy-data' ], function () {
 
                 return minStepsProgram;
             }),
-            minStepsParProgram: programs.reduce(function (minStepsParProgram, program) {
+            minStepsParProgram: programs.filter(program => program.legal).reduce(function (minStepsParProgram, program) {
                 if (program.size <= level.challenge.size) {
                     if (minStepsParProgram.size > level.challenge.size) {
                         minStepsParProgram = program;
@@ -291,6 +293,23 @@ gulp.task('deploy-page', [ 'deploy-data' ], function () {
                 }
 
                 return minStepsParProgram;
+            }),
+            minStepsLaxProgram: programs.reduce(function (minStepsLaxProgram, program) {
+                if (program.steps < minStepsLaxProgram.steps
+                    || program.steps === minStepsLaxProgram.steps && program.size < minStepsLaxProgram.size) {
+                    minStepsLaxProgram = program;
+                }
+
+                return minStepsLaxProgram;
+            }),
+            minStepsWorkyProgram: programs.filter(program => program.worky)
+                 .reduce(function (minStepsWorkyProgram, program) {
+                if (program.steps < minStepsWorkyProgram.steps
+                    || program.steps === minStepsWorkyProgram.steps && program.size < minStepsWorkyProgram.size) {
+                    minStepsWorkyProgram = program;
+                }
+
+                return minStepsWorkyProgram;
             }),
             instructionsHtml: marked(level.instructions),
             commandsHtml: level.commands

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -216,8 +216,8 @@ gulp.task('deploy-data-programs', [ 'deploy-clean' ], function () {
                 steps: data.path.reportedSpeed, // data.averageSteps, // @todo until step measurement matches game's
                 successRatio: data.successRatio,
                 type: data.path.type,
-                legal: ( (!/(exploit|specific|obsolete)/.exec(data.path.type)) && ((data.successRatio == 1) || ([4, 28, 41].includes(data.level.number))) ),
-                worky: ((data.successRatio == 1) || ([4, 28, 41].includes(data.level.number))),
+                legal: ( (!/(exploit|specific|obsolete)/.test(data.path.type)) && ((data.successRatio === 1) || ([4, 28, 41].includes(data.level.number))) ),
+                worky: ((data.successRatio === 1) || ([4, 28, 41].includes(data.level.number))),
                 author: data.path.author,
                 hash: md5(data.source),
                 path: data.path.full

--- a/index.html
+++ b/index.html
@@ -68,10 +68,12 @@
 
     <h2>Top Scores</h2>
 
+    <h3>Non input-specific</h3>
+
     <table class="table table-condensed table-bordered table-hover">
         <tr>
-            <th><div align="right">Level</div></th>
-            <th>Name</th>
+            <th width="60px"><div align="right">Level</div></th>
+            <th width="230px">Name</th>
             <th>Size/Par</th>
             <th>Speed/Par</th>
             <th>Smallest That Meets Speed Challenge</th>
@@ -106,6 +108,49 @@
             <td><a href="https://github.com/atesgoral/hrm-solutions/blob/master/solutions/<%= level.minStepsProgram.path %>"><%= level.minStepsProgram.steps + '/' + level.challenge.speed %></a> by <a href="<%= 'https://github.com/' + level.minStepsProgram.author %>"><%= '@' + level.minStepsProgram.author %></a></td>
             <td><a href="https://github.com/atesgoral/hrm-solutions/blob/master/solutions/<%= level.minSizeParProgram.path %>"><%= level.minSizeParProgram.size + '/' + level.challenge.size %></a> by <a href="https://github.com/<%= level.minSizeParProgram.author %>">@<%= level.minSizeParProgram.author %></a> (in <%= level.minSizeParProgram.steps + '/' + level.challenge.speed %>)</td>
             <td><a href="https://github.com/atesgoral/hrm-solutions/blob/master/solutions/<%= level.minStepsParProgram.path %>"><%= level.minStepsParProgram.steps + '/' + level.challenge.speed %></a> by <a href="<%= 'https://github.com/' + level.minStepsParProgram.author %>"><%= '@' + level.minStepsParProgram.author %></a> (in <%= level.minStepsParProgram.size + '/' + level.challenge.size %>)</td>
+        </tr>
+        <%
+            }
+        });
+        %>
+    </table>
+
+    <h3>Fastest Programs, Input-specific Code Allowed</h3>
+
+    <table class="table table-condensed table-bordered table-hover">
+        <tr>
+            <th width="60px"><div align="right">Level</div></th>
+            <th width="230px">Name</th>
+            <th>Fastest (Input-specific allowed)</th>
+            <th>Fastest (Input-specific allowed, all tests pass)</th>
+        </tr>
+        <%
+        _.forEach(topScores, function (level) {
+            if (level.cutscene) {
+        %>
+        <tr class="text-muted">
+            <td align="right"><%= level.number %></td>
+            <td colspan="5"><%= level.name %></td>
+        </tr>
+        <%
+            } else {
+        %>
+        <tr>
+            <td align="right"><%= level.number %></td>
+            <td>
+                <%= level.name %>
+                <span class="level-data text-info pull-right glyphicon glyphicon-info-sign" title="Instructions" aria-hidden="true" data-toggle="popover" data-trigger="hover" data-placement="right" data-html="true" data-content="<%- level.instructionsHtml %>"></span>
+                <span class="level-data text-info pull-right glyphicon glyphicon-cog" title="Allowed" aria-hidden="true" data-toggle="popover" data-trigger="hover" data-placement="right" data-html="true" data-content="<%- level.commandsHtml + '\n' + level.featuresHtml %>"></span>
+                <%
+                if (level.floorHtml) {
+                %>
+                <span class="level-data text-info pull-right glyphicon glyphicon-th" title="Floor" aria-hidden="true" data-toggle="popover" data-trigger="hover" data-placement="right" data-html="true" data-content="<%- level.floorHtml %>"></span>
+                <%
+                }
+                %>
+            </td>
+            <td><a href="https://github.com/atesgoral/hrm-solutions/blob/master/solutions/<%= level.minStepsLaxProgram.path %>"><%= level.minStepsLaxProgram.steps + '/' + level.challenge.speed %></a> by <a href="<%= 'https://github.com/' + level.minStepsLaxProgram.author %>"><%= '@' + level.minStepsLaxProgram.author %></a> (in <%= level.minStepsLaxProgram.size + '/' + level.challenge.size %><% if (![4,28,41].includes(level.number)) { %>, <%= level.minStepsLaxProgram.successRatio * 100 %>% pass<% } %>)</td>
+            <td><a href="https://github.com/atesgoral/hrm-solutions/blob/master/solutions/<%= level.minStepsWorkyProgram.path %>"><%= level.minStepsWorkyProgram.steps + '/' + level.challenge.speed %></a> by <a href="<%= 'https://github.com/' + level.minStepsWorkyProgram.author %>"><%= '@' + level.minStepsWorkyProgram.author %></a> (in <%= level.minStepsWorkyProgram.size + '/' + level.challenge.size %><%= (level.minStepsWorkyProgram.legal ? ", not input-specific" : "") %>)</td>
         </tr>
         <%
             }


### PR DESCRIPTION
The fastest general-input solution is more interesting than the "exploit/10% of tests pass" solution, though all are worth mentioning. 

This patch makes the main table only show 'legal' solutions: ones for which all tests pass and the file is not annotated as obsolete, specific, or exploit. A separate table lists the fastest overall regardless of test passing or input specificity; and the fastest overall that passes all tests. I had to fudge the legality of programs on floors 4, 28, and 41 because the test suite fails to handle sorted input correctly.