### PR TITLE
Level 23 new speed record (size: 19, speed: 69)

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -73,3 +73,4 @@
 - ironwallaby
 - ichbineinNerd
 - [ landfillbaby, Lucy Phipps ]
+- [ Whathecode, Steven Jeuris ]

--- a/solutions/23-The-Littlest-Number-13.75/19.69-whathecode.asm
+++ b/solutions/23-The-Littlest-Number-13.75/19.69-whathecode.asm
@@ -1,0 +1,55 @@
+-- HUMAN RESOURCE MACHINE PROGRAM --
+
+    JUMP     d
+a:
+    COPYFROM 0
+    JUMP     c
+b:
+    COPYFROM 1
+c:
+    OUTBOX  
+d:
+    COMMENT  0
+    INBOX   
+    COPYTO   0
+e:
+f:
+    INBOX   
+    JUMPZ    a
+    COPYTO   1
+    SUB      0
+    JUMPN    g
+    JUMP     e
+g:
+    COMMENT  1
+h:
+    INBOX   
+    JUMPZ    b
+    COPYTO   0
+    SUB      1
+    JUMPN    f
+    JUMP     h
+
+
+DEFINE COMMENT 0
+eJxTZ2BgKLDoWvzTp84uN3C2anxYW9G1SKNJQGEGTve92cfdGfKqfJryVwb9yQKJxba5u2Y0nfX8WX0v
+lL18Q9LVQu+yNw1aPRe7qqaD5A+sYHGuXiXos2P1n6zvqyFiu1ftsMpbv8VcZlul9aSdBx0m7Orzmrrj
+VtDWNTsz5LYezJu1ra1IbEdITcT2mKbMjZ8n5a2vmv59tf1shlEwCkYBzQEA+dVFfA;
+
+DEFINE COMMENT 1
+eJxTZWBgWGVlZplttaRd0zpkFZDLkG1VanHQc4fVHu8/Nnu821wcvAR9+Fy14ubaf0+fb/c9vde1Lqfe
+62TJb++I+t/eS9ptvXP72Dz+zFhq078MpN+s9rOZdXWdXXT+mvjVmX+yPtY97wSJsy5P7fi/wiz909rP
+Zpkbz0ov3XRJ7sxuHs/SIwGVIPnvq2NCzI5c8mEYBaNgFNANAAAD5D29;
+
+DEFINE LABEL 0
+eJzjZmBgeJTTdq66+nEbw8QNbFkzjczk54r6ty1zX6izYc1LoDRDRlNEfeCi6XUMRIAMa8UIQReecu2g
+k26vAxPCP/pPrzMIuNcMkrsQvaaXIWlL6o6UNherlBC/DelaPSBxpsRz5SD6f2WAt12VbKhn2bml/ysF
+V2g2uS8EiZdPeR5tO6kpn2Eiy/yaSe4LP089Ol92XtV0kNzqDStiVmz8np62aX6L4pYtk2dtM5s6YVfp
+FIhcV6n3nrocEPv5RsWINcdPuoHY/Zfmh0mcTwh/eeJ1nPaJDUkLT//J8rriXcZ6TbTW/ersRonzhROX
+nPozA6RW6KVs6IWXHCVhzyH8kjuyoSEvVsQcfbsi5tOXmBBiwmQUjILBDABtU3cg;
+
+DEFINE LABEL 1
+eJyTYWBgmFHwx+Z8sVGKd+mtdcfLnM8AhRgmFJdasFSsMcxufK4b2rlCL6B7jWFX70EHjr4A767eW0Hn
+utWi5dr+ZG2qO1d+tDykJrZNtFagW7LBo29F17E+vX62/rpZHH0hqy52vd51s33nkYL6tnPOFd0XGUbB
+KBgFgwoAAGy9M2k;
+


### PR DESCRIPTION
Speed is 1 less than current record.

The solution relies on swapping out which memory address holds the current value with the one holding the smallest value by switching to a different algorithm whenever a new smallest value is found, rather than always copying the new smallest value to the same field. This saves copy operations and thereby speed.

Unfortunately running `npm install` is failing on:

> npm ERR! path git
> npm ERR! code ENOENT
> npm ERR! errno ENOENT
> npm ERR! syscall spawn git
> npm ERR! enoent Error while executing:
> npm ERR! enoent undefined ls-remote -h -t https://github.com/tekd/gulp-gh-pages.git
> npm ERR! enoent
> npm ERR! enoent
> npm ERR! enoent spawn git ENOENT
> npm ERR! enoent This is related to npm not being able to find a file.

Therefore, I can't run `npm test`, but it passes in the game. =)
