### PR TITLE
Pin CI to Node.js 20

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -12,6 +12,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
       - name: Install
         run: yarn
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
       - name: Install
         run: yarn
 


### PR DESCRIPTION
## Summary

- pin the test and deploy workflows to Node.js 20 with `actions/setup-node@v6`
- leave the application code, dependencies, lockfile, and runner image untouched

## Why

The GitHub runner's default Node.js version moved from 20 to 22. `canvas@2.11.2` has no prebuilt binary for Node.js 22, so installation falls back to native compilation and fails because the runner does not include the graphics development packages.

This intentionally restores the site's last known-good build toolchain rather than adding a native compiler stack or modernizing unrelated code. It is the narrow alternative to #395.

## Testing

Locally with Node.js 20.20.2 and Yarn 1.22.22:

- `yarn install --frozen-lockfile`
- `yarn test`
- `yarn build`
