### PR TITLE
Update checkout action to v7

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

- update `actions/checkout` from v4 to v7 in both workflows
- leave the application Node.js version and deploy action unchanged

## Why

`checkout@v4` runs on the deprecated Node.js 20 action runtime and now emits a warning on every job. v7 uses the current Node.js 24 action runtime.

`actions/setup-node` is already on its current major (v6), and the latest major of `JamesIves/github-pages-deploy-action` remains v4.

## Testing

- `git diff --check`
- GitHub Actions exercises both checkout and the test workflow on this pull request
